### PR TITLE
Resolve naming collisions and compile errors

### DIFF
--- a/ESP32_SIM800_Arduino/ESP32_SIM800.ino
+++ b/ESP32_SIM800_Arduino/ESP32_SIM800.ino
@@ -25,6 +25,16 @@ struct TestResults {
 
 TestResults testResults;
 
+// Function prototypes
+void runBasicATTests();
+void runSIMCardTest();
+void runNetworkTests();
+void runGPSTests();
+void runGPRSTests();
+void runHTTPTests();
+void runMQTTTests();
+void printTestSummary();
+
 void setup() {
   // Initialize serial for debug output
   Serial.begin(DEBUG_BAUD);

--- a/ESP32_SIM800_Arduino/SIM800Manager.cpp
+++ b/ESP32_SIM800_Arduino/SIM800Manager.cpp
@@ -5,8 +5,8 @@ SIM800Manager::SIM800Manager() {
   responseBuffer = "";
   lastCommandTime = 0;
   isInitialized = false;
-  isGPRSConnected = false;
-  isGPSEnabled = false;
+  gprsConnected = false;
+  gpsEnabled = false;
 }
 
 SIM800Manager::~SIM800Manager() {
@@ -203,7 +203,7 @@ bool SIM800Manager::connectGPRS() {
   String response;
   if (sendCommand("AT+SAPBR=2,1", response) == SIM800_OK) {
     if (response.indexOf("1,1,") >= 0) {  // Already connected
-      isGPRSConnected = true;
+      gprsConnected = true;
       return true;
     }
   }
@@ -215,7 +215,7 @@ bool SIM800Manager::connectGPRS() {
     // Verify connection
     if (sendCommand("AT+SAPBR=2,1", response) == SIM800_OK) {
       if (response.indexOf("1,1,") >= 0) {
-        isGPRSConnected = true;
+        gprsConnected = true;
         DEBUG_PRINTLN("GPRS connected successfully");
         return true;
       }
@@ -228,14 +228,14 @@ bool SIM800Manager::connectGPRS() {
 
 bool SIM800Manager::disconnectGPRS() {
   if (sendCommand("AT+SAPBR=0,1") == SIM800_OK) {
-    isGPRSConnected = false;
+    gprsConnected = false;
     return true;
   }
   return false;
 }
 
 bool SIM800Manager::isGPRSConnected() {
-  return isGPRSConnected;
+  return gprsConnected;
 }
 
 bool SIM800Manager::getIPAddress(String& ip) {
@@ -271,21 +271,21 @@ bool SIM800Manager::enableGPS() {
     return false;
   }
   
-  isGPSEnabled = true;
+  gpsEnabled = true;
   DEBUG_PRINTLN("GPS enabled successfully");
   return true;
 }
 
 bool SIM800Manager::disableGPS() {
   if (sendCommand("AT+CGPSPWR=0") == SIM800_OK) {
-    isGPSEnabled = false;
+    gpsEnabled = false;
     return true;
   }
   return false;
 }
 
 bool SIM800Manager::isGPSEnabled() {
-  return isGPSEnabled;
+  return gpsEnabled;
 }
 
 bool SIM800Manager::getGPSData(GPSData& gpsData) {
@@ -624,8 +624,8 @@ bool SIM800Manager::performDiagnostics() {
 void SIM800Manager::printStatus() {
   DEBUG_PRINTLN("=== SIM800 Status ===");
   DEBUG_PRINTLN("Initialized: " + String(isInitialized ? "Yes" : "No"));
-  DEBUG_PRINTLN("GPRS Connected: " + String(isGPRSConnected ? "Yes" : "No"));
-  DEBUG_PRINTLN("GPS Enabled: " + String(isGPSEnabled ? "Yes" : "No"));
+  DEBUG_PRINTLN("GPRS Connected: " + String(gprsConnected ? "Yes" : "No"));
+  DEBUG_PRINTLN("GPS Enabled: " + String(gpsEnabled ? "Yes" : "No"));
   
   String imei, iccid;
   if (getIMEI(imei)) {

--- a/ESP32_SIM800_Arduino/SIM800Manager.h
+++ b/ESP32_SIM800_Arduino/SIM800Manager.h
@@ -49,13 +49,13 @@ private:
   String responseBuffer;
   unsigned long lastCommandTime;
   bool isInitialized;
-  bool isGPRSConnected;
-  bool isGPSEnabled;
+  bool gprsConnected;
+  bool gpsEnabled;
   
   // Private helper methods
   void clearBuffer();
-  String readResponse(unsigned long timeout = SIM800_TIMEOUT);
-  bool waitForResponse(const String& expectedResponse, unsigned long timeout = SIM800_TIMEOUT);
+  String readResponse(unsigned long timeout = SIM800_CMD_TIMEOUT);
+  bool waitForResponse(const String& expectedResponse, unsigned long timeout = SIM800_CMD_TIMEOUT);
   void flushSerial();
   
 public:
@@ -109,10 +109,10 @@ public:
   bool mqttDisconnect();
   
   // Utility functions
-  SIM800Response sendCommand(const String& command, const String& expectedResponse = "OK", 
-                            unsigned long timeout = SIM800_TIMEOUT);
-  SIM800Response sendCommand(const String& command, String& response, 
-                            const String& expectedResponse = "OK", unsigned long timeout = SIM800_TIMEOUT);
+  SIM800Response sendCommand(const String& command, const String& expectedResponse = "OK",
+                            unsigned long timeout = SIM800_CMD_TIMEOUT);
+  SIM800Response sendCommand(const String& command, String& response,
+                            const String& expectedResponse = "OK", unsigned long timeout = SIM800_CMD_TIMEOUT);
   void printDebug(const String& message);
   
   // Status monitoring

--- a/ESP32_SIM800_Arduino/config.h
+++ b/ESP32_SIM800_Arduino/config.h
@@ -10,7 +10,7 @@
 
 // Serial Configuration
 #define DEBUG_BAUD 115200
-#define SIM800_TIMEOUT 10000  // 10 seconds timeout for commands
+#define SIM800_CMD_TIMEOUT 10000  // 10 seconds timeout for commands
 #define GPS_TIMEOUT 30000     // 30 seconds for GPS fix
 
 // Network Configuration

--- a/ESP32_SIM800_Arduino/examples/BasicUsage/SIM800Manager.cpp
+++ b/ESP32_SIM800_Arduino/examples/BasicUsage/SIM800Manager.cpp
@@ -5,8 +5,8 @@ SIM800Manager::SIM800Manager() {
   responseBuffer = "";
   lastCommandTime = 0;
   isInitialized = false;
-  isGPRSConnected = false;
-  isGPSEnabled = false;
+  gprsConnected = false;
+  gpsEnabled = false;
 }
 
 SIM800Manager::~SIM800Manager() {
@@ -203,7 +203,7 @@ bool SIM800Manager::connectGPRS() {
   String response;
   if (sendCommand("AT+SAPBR=2,1", response) == SIM800_OK) {
     if (response.indexOf("1,1,") >= 0) {  // Already connected
-      isGPRSConnected = true;
+      gprsConnected = true;
       return true;
     }
   }
@@ -215,7 +215,7 @@ bool SIM800Manager::connectGPRS() {
     // Verify connection
     if (sendCommand("AT+SAPBR=2,1", response) == SIM800_OK) {
       if (response.indexOf("1,1,") >= 0) {
-        isGPRSConnected = true;
+        gprsConnected = true;
         DEBUG_PRINTLN("GPRS connected successfully");
         return true;
       }
@@ -228,14 +228,14 @@ bool SIM800Manager::connectGPRS() {
 
 bool SIM800Manager::disconnectGPRS() {
   if (sendCommand("AT+SAPBR=0,1") == SIM800_OK) {
-    isGPRSConnected = false;
+    gprsConnected = false;
     return true;
   }
   return false;
 }
 
 bool SIM800Manager::isGPRSConnected() {
-  return isGPRSConnected;
+  return gprsConnected;
 }
 
 bool SIM800Manager::getIPAddress(String& ip) {
@@ -271,21 +271,21 @@ bool SIM800Manager::enableGPS() {
     return false;
   }
   
-  isGPSEnabled = true;
+  gpsEnabled = true;
   DEBUG_PRINTLN("GPS enabled successfully");
   return true;
 }
 
 bool SIM800Manager::disableGPS() {
   if (sendCommand("AT+CGPSPWR=0") == SIM800_OK) {
-    isGPSEnabled = false;
+    gpsEnabled = false;
     return true;
   }
   return false;
 }
 
 bool SIM800Manager::isGPSEnabled() {
-  return isGPSEnabled;
+  return gpsEnabled;
 }
 
 bool SIM800Manager::getGPSData(GPSData& gpsData) {
@@ -624,8 +624,8 @@ bool SIM800Manager::performDiagnostics() {
 void SIM800Manager::printStatus() {
   DEBUG_PRINTLN("=== SIM800 Status ===");
   DEBUG_PRINTLN("Initialized: " + String(isInitialized ? "Yes" : "No"));
-  DEBUG_PRINTLN("GPRS Connected: " + String(isGPRSConnected ? "Yes" : "No"));
-  DEBUG_PRINTLN("GPS Enabled: " + String(isGPSEnabled ? "Yes" : "No"));
+  DEBUG_PRINTLN("GPRS Connected: " + String(gprsConnected ? "Yes" : "No"));
+  DEBUG_PRINTLN("GPS Enabled: " + String(gpsEnabled ? "Yes" : "No"));
   
   String imei, iccid;
   if (getIMEI(imei)) {

--- a/ESP32_SIM800_Arduino/examples/BasicUsage/SIM800Manager.h
+++ b/ESP32_SIM800_Arduino/examples/BasicUsage/SIM800Manager.h
@@ -49,13 +49,13 @@ private:
   String responseBuffer;
   unsigned long lastCommandTime;
   bool isInitialized;
-  bool isGPRSConnected;
-  bool isGPSEnabled;
+  bool gprsConnected;
+  bool gpsEnabled;
   
   // Private helper methods
   void clearBuffer();
-  String readResponse(unsigned long timeout = SIM800_TIMEOUT);
-  bool waitForResponse(const String& expectedResponse, unsigned long timeout = SIM800_TIMEOUT);
+  String readResponse(unsigned long timeout = SIM800_CMD_TIMEOUT);
+  bool waitForResponse(const String& expectedResponse, unsigned long timeout = SIM800_CMD_TIMEOUT);
   void flushSerial();
   
 public:
@@ -109,10 +109,10 @@ public:
   bool mqttDisconnect();
   
   // Utility functions
-  SIM800Response sendCommand(const String& command, const String& expectedResponse = "OK", 
-                            unsigned long timeout = SIM800_TIMEOUT);
-  SIM800Response sendCommand(const String& command, String& response, 
-                            const String& expectedResponse = "OK", unsigned long timeout = SIM800_TIMEOUT);
+  SIM800Response sendCommand(const String& command, const String& expectedResponse = "OK",
+                            unsigned long timeout = SIM800_CMD_TIMEOUT);
+  SIM800Response sendCommand(const String& command, String& response,
+                            const String& expectedResponse = "OK", unsigned long timeout = SIM800_CMD_TIMEOUT);
   void printDebug(const String& message);
   
   // Status monitoring

--- a/ESP32_SIM800_Arduino/examples/BasicUsage/config.h
+++ b/ESP32_SIM800_Arduino/examples/BasicUsage/config.h
@@ -10,7 +10,7 @@
 
 // Serial Configuration
 #define DEBUG_BAUD 115200
-#define SIM800_TIMEOUT 10000  // 10 seconds timeout for commands
+#define SIM800_CMD_TIMEOUT 10000  // 10 seconds timeout for commands
 #define GPS_TIMEOUT 30000     // 30 seconds for GPS fix
 
 // Network Configuration

--- a/src/SIM800Manager.cpp
+++ b/src/SIM800Manager.cpp
@@ -5,8 +5,8 @@ SIM800Manager::SIM800Manager() {
   responseBuffer = "";
   lastCommandTime = 0;
   isInitialized = false;
-  isGPRSConnected = false;
-  isGPSEnabled = false;
+  gprsConnected = false;
+  gpsEnabled = false;
 }
 
 SIM800Manager::~SIM800Manager() {
@@ -203,7 +203,7 @@ bool SIM800Manager::connectGPRS() {
   String response;
   if (sendCommand("AT+SAPBR=2,1", response) == SIM800_OK) {
     if (response.indexOf("1,1,") >= 0) {  // Already connected
-      isGPRSConnected = true;
+      gprsConnected = true;
       return true;
     }
   }
@@ -215,7 +215,7 @@ bool SIM800Manager::connectGPRS() {
     // Verify connection
     if (sendCommand("AT+SAPBR=2,1", response) == SIM800_OK) {
       if (response.indexOf("1,1,") >= 0) {
-        isGPRSConnected = true;
+        gprsConnected = true;
         DEBUG_PRINTLN("GPRS connected successfully");
         return true;
       }
@@ -228,14 +228,14 @@ bool SIM800Manager::connectGPRS() {
 
 bool SIM800Manager::disconnectGPRS() {
   if (sendCommand("AT+SAPBR=0,1") == SIM800_OK) {
-    isGPRSConnected = false;
+    gprsConnected = false;
     return true;
   }
   return false;
 }
 
 bool SIM800Manager::isGPRSConnected() {
-  return isGPRSConnected;
+  return gprsConnected;
 }
 
 bool SIM800Manager::getIPAddress(String& ip) {
@@ -271,21 +271,21 @@ bool SIM800Manager::enableGPS() {
     return false;
   }
   
-  isGPSEnabled = true;
+  gpsEnabled = true;
   DEBUG_PRINTLN("GPS enabled successfully");
   return true;
 }
 
 bool SIM800Manager::disableGPS() {
   if (sendCommand("AT+CGPSPWR=0") == SIM800_OK) {
-    isGPSEnabled = false;
+    gpsEnabled = false;
     return true;
   }
   return false;
 }
 
 bool SIM800Manager::isGPSEnabled() {
-  return isGPSEnabled;
+  return gpsEnabled;
 }
 
 bool SIM800Manager::getGPSData(GPSData& gpsData) {
@@ -624,8 +624,8 @@ bool SIM800Manager::performDiagnostics() {
 void SIM800Manager::printStatus() {
   DEBUG_PRINTLN("=== SIM800 Status ===");
   DEBUG_PRINTLN("Initialized: " + String(isInitialized ? "Yes" : "No"));
-  DEBUG_PRINTLN("GPRS Connected: " + String(isGPRSConnected ? "Yes" : "No"));
-  DEBUG_PRINTLN("GPS Enabled: " + String(isGPSEnabled ? "Yes" : "No"));
+  DEBUG_PRINTLN("GPRS Connected: " + String(gprsConnected ? "Yes" : "No"));
+  DEBUG_PRINTLN("GPS Enabled: " + String(gpsEnabled ? "Yes" : "No"));
   
   String imei, iccid;
   if (getIMEI(imei)) {

--- a/src/SIM800Manager.h
+++ b/src/SIM800Manager.h
@@ -49,13 +49,13 @@ private:
   String responseBuffer;
   unsigned long lastCommandTime;
   bool isInitialized;
-  bool isGPRSConnected;
-  bool isGPSEnabled;
+  bool gprsConnected;
+  bool gpsEnabled;
   
   // Private helper methods
   void clearBuffer();
-  String readResponse(unsigned long timeout = SIM800_TIMEOUT);
-  bool waitForResponse(const String& expectedResponse, unsigned long timeout = SIM800_TIMEOUT);
+  String readResponse(unsigned long timeout = SIM800_CMD_TIMEOUT);
+  bool waitForResponse(const String& expectedResponse, unsigned long timeout = SIM800_CMD_TIMEOUT);
   void flushSerial();
   
 public:
@@ -109,10 +109,10 @@ public:
   bool mqttDisconnect();
   
   // Utility functions
-  SIM800Response sendCommand(const String& command, const String& expectedResponse = "OK", 
-                            unsigned long timeout = SIM800_TIMEOUT);
-  SIM800Response sendCommand(const String& command, String& response, 
-                            const String& expectedResponse = "OK", unsigned long timeout = SIM800_TIMEOUT);
+  SIM800Response sendCommand(const String& command, const String& expectedResponse = "OK",
+                            unsigned long timeout = SIM800_CMD_TIMEOUT);
+  SIM800Response sendCommand(const String& command, String& response,
+                            const String& expectedResponse = "OK", unsigned long timeout = SIM800_CMD_TIMEOUT);
   void printDebug(const String& message);
   
   // Status monitoring

--- a/src/config.h
+++ b/src/config.h
@@ -10,7 +10,7 @@
 
 // Serial Configuration
 #define DEBUG_BAUD 115200
-#define SIM800_TIMEOUT 10000  // 10 seconds timeout for commands
+#define SIM800_CMD_TIMEOUT 10000  // 10 seconds timeout for commands
 #define GPS_TIMEOUT 30000     // 30 seconds for GPS fix
 
 // Network Configuration

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,16 @@ struct TestResults {
 
 TestResults testResults;
 
+// Function prototypes
+void runBasicATTests();
+void runSIMCardTest();
+void runNetworkTests();
+void runGPSTests();
+void runGPRSTests();
+void runHTTPTests();
+void runMQTTTests();
+void printTestSummary();
+
 void setup() {
   // Initialize serial for debug output
   Serial.begin(DEBUG_BAUD);


### PR DESCRIPTION
## Summary
- Rename SIM800 command timeout macro to avoid enum collisions
- Replace conflicting boolean members with clearer names and update timeouts
- Add forward declarations for test helpers to satisfy the compiler

## Testing
- `platformio run` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68989abc95708322b529519ddd06c286